### PR TITLE
Correct $jdk_folder location

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 #requires -Version 5.0
 $java_folder = "$env:ProgramFiles\Java"
-$jdk_folder = "$java_folder\jdk-17"
+$jdk_folder = "$java_folder\jdk-18"
 $bin_folder = "$jdk_folder\bin"
 
 


### PR DESCRIPTION
Making folder name reference 18 following the bump (from 17) to the jdk installed in commit 8b30890a06c479da27f9ef18960b1779077a6ae1